### PR TITLE
Add hot reloading with bevy_hotpatching_experiments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ bevy = { version = "0.18.0", default-features = false, features = [
   "x11",
 ] }
 bevy-inspector-egui = "0.36.0"
+bevy_hotpatching_experiments = "0.4.0"
 bevy_landmass = "0.11.0"
 bevy_rerecast = "0.4.0"
 bevy_seedling = "0.7.0"


### PR DESCRIPTION
This PR integrates bevy_hotpatching_experiments to enable hot reloading.

- Supports dx serve --hot-patch
- Allows #[hot] systems
- Improves iteration speed

Closes #8
